### PR TITLE
Chore/upgrade workspace 20260525

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- build info-->
     <!-- ============================================================================ -->
     <!-- Set the target framework for all projects -->
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <!-- Set the configuration to Debug by default -->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <!-- Enable nullable reference types -->
@@ -20,7 +20,7 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>syrx;data access;orm;micro-orm</PackageTags>
-    <PackageReleaseNotes>Last release on .NET8.0 exclusively. Next release will include .NET9.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Release aligned to .NET 10 exclusively.</PackageReleaseNotes>
     <!-- ============================================================================ -->
     <!-- organization info -->
     <!-- ============================================================================ -->

--- a/src/Syrx.Commanders.Databases.Connectors.MySql.Extensions/Syrx.Commanders.Databases.Connectors.MySql.Extensions.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.MySql.Extensions/Syrx.Commanders.Databases.Connectors.MySql.Extensions.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Syrx.Commanders.Databases.Connectors.MySql/Syrx.Commanders.Databases.Connectors.MySql.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.MySql/Syrx.Commanders.Databases.Connectors.MySql.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MySqlConnector" Version="2.4.0" />
+		<PackageReference Include="MySqlConnector" Version="2.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
@@ -37,3 +37,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" /> 
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" /> 
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Extensions.Tests.Unit.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" /> 
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit/Syrx.Commanders.Databases.Connectors.MySql.Tests.Unit.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates the project to target .NET 10.0 exclusively and aligns all dependencies and documentation accordingly. It also upgrades several NuGet package dependencies to their latest major versions to ensure compatibility with .NET 10.0. The submodule for `Syrx.Commanders.Databases` is also updated.

.NET Version Alignment:

* Changed the target framework for all projects and test projects from `net8.0` to `net10.0` to align with the latest .NET release. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL7-R7) [[2]](diffhunk://#diff-f10740e8a031ccaf86d9037823752026a3a7ba7388bd8dbb97b816cf725da521L1-R4) [[3]](diffhunk://#diff-eaf2dd1a8cb252629e9015368088805480a7efd4a311cb8b9ad9cd9826274fecL4-R4) [[4]](diffhunk://#diff-83b20e2e4ae997242661000f51c7f071fe3e9d1b7529e5d3fa82ab423bf91486L4-R4)
* Updated release notes in `Directory.Build.props` to indicate exclusive support for .NET 10.0.

Dependency Upgrades:

* Upgraded major NuGet dependencies to their latest versions, including `Microsoft.Extensions.DependencyInjection`, `MySqlConnector`, `coverlet.collector`, `Microsoft.Extensions.Logging.Console`, `Microsoft.NET.Test.Sdk`, and `xunit.runner.visualstudio` to ensure compatibility with .NET 10.0. [[1]](diffhunk://#diff-d1812a89a6ec86dd4e73dd14287f4f1983089c38dfab8ed31a06aa2b9e5ff911L8-R8) [[2]](diffhunk://#diff-861a0326792b50b262c8bcd2dc819903875e52fa9a86e125f80d3240e197aa94L8-R8) [[3]](diffhunk://#diff-f10740e8a031ccaf86d9037823752026a3a7ba7388bd8dbb97b816cf725da521L13-R21) [[4]](diffhunk://#diff-eaf2dd1a8cb252629e9015368088805480a7efd4a311cb8b9ad9cd9826274fecL13-R19) [[5]](diffhunk://#diff-83b20e2e4ae997242661000f51c7f071fe3e9d1b7529e5d3fa82ab423bf91486L13-R19)

Submodule Update:

* Updated the `Syrx.Commanders.Databases` submodule to the latest commit.