### PR TITLE
deps: upgrade mysql residual testcontainers and reproducible builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <!-- ============================================================================ -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/integration/Syrx.MySql.Tests.Integration/MySqlFixture.cs
+++ b/tests/integration/Syrx.MySql.Tests.Integration/MySqlFixture.cs
@@ -13,9 +13,8 @@ namespace Syrx.MySql.Tests.Integration
                 .AddSystemdConsole()
                 .AddSimpleConsole()).CreateLogger<MySqlFixture>();
 
-            _container = new MySqlBuilder()
-    //.WithImage("mysql:8.0")
-    .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(3306))
+                _container = new MySqlBuilder("mysql:8.0")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(3306))
     .WithReuse(true)
     .WithLogger(_logger)
     .WithStartupCallback((container, token) =>

--- a/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.MySql.Tests.Integration/Syrx.MySql.Tests.Integration.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Testcontainers.MySql" Version="4.6.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates dependencies and improves the MySQL test container setup for integration tests. The main changes are upgrading package versions for better compatibility and reliability, and refining how the MySQL container is started and waited on in tests.

Dependency upgrades:

* Upgraded `DotNet.ReproducibleBuilds` from version 1.2.25 to 2.0.2 in `Directory.Build.props` for improved reproducible builds support.
* Upgraded `Testcontainers.MySql` from version 4.6.0 to 4.12.0 in `Syrx.MySql.Tests.Integration.csproj` to use the latest features and bug fixes.

Test container improvements:

* Updated the MySQL test container setup in `MySqlFixture.cs` to explicitly specify the image version (`mysql:8.0`), use the new `UntilInternalTcpPortIsAvailable` wait strategy, and improved container reuse and logging.